### PR TITLE
In Nest, the POST request will return 201 as Created response by defa…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ export default class HttpClient {
         console.log(res);
 
         const data: string = JSON.stringify(res.data);
-        if (res.status === 200) {
+        if (res.status >= 200 && res.status<300) {
           return Convert.jsonToModel(data) as T;
         } else {
           return Promise.reject(data);


### PR DESCRIPTION
In Nest, the POST request will return 201 as Created response by default, but it will be rejected by axios-mapper. More general, we think the status start with 2 should be considered as succeeded request and accept the result, but not reject with no hint.